### PR TITLE
Make kaluza look less jumpy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ dist:
 
 dist/jamescondron_%_cv.pdf: %/cv.tex $(INCLUDES) | dist
 	xelatex -jobname=$(basename $@) $<
+
+.PHONY: spellcheck
+spellcheck: */*.tex
+	for F in $(shell git diff --name-only); do aspell --mode=tex check $$F; done

--- a/includes/employment.tex
+++ b/includes/employment.tex
@@ -2,28 +2,29 @@
 
 \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}}ll}
   \entry
-  {January 2023 - May 2023}
+  {March 2022 - May 2023}
   {Kaluza - a Green Energy PaaS}
-  {Software Engineering Manager - Event Streaming Platform}
-  {Management of a small team of Scala engineers building high performance streaming software. Engagement on this team was low when I joined; most of the team hadn't seen a promotion for several years. By setting up a goal-framing framework and encouraging the team to join squad/ company level initiatives, all IC level engineers on the team had open promotion cases.}
+  {Software Engineering Manager}
+  {\textit{Developer Experience}: Inherited a team of three engineers with low engagement and poor morale. Built a product vision and strategy, including KPIs, walked the team through setting mission/vision (with 100\% buy-in), and set clear progression paths. Through ownership of recruitment, I grew this team to eight people in six months without jeopardising culture, frequently topping the charts for engagement metrics in company-wide surveys.}
+
 
   \entry
-  {January 2023 - May 2023}
-  {Kaluza - a Green Energy PaaS}
-  {Software Engineering Manager - Data and Analytics Platform}
-  {Merge of the previous Analytics Platform with another (Data Warehousing) team, setting capacity and delivery plans and building programmes and processes to upskill Data Analysts to become Analytics Engineers competent in Scala. Management of the team through a re-architecture of the platform, while increasing the rate at which initiatives were delivered with no increase to budget or headcount}
+  {}
+  {}
+  {}
+  {\textit{Analytics Platform}: Genesis of a Data and Analytics Engineering Team, building out a Data Platform. Breaking silos between Data Engineers and Analysts to build T-shaped engineers, increasing a feeling of personal ownership among those engineers. Technical and architectural oversight of new features by facilitating workshops and whiteboard sessions.}
 
   \entry
-  {August 2022 - January 2023}
-  {Kaluza - a Green Energy PaaS}
-  {Software Engineering Manager - Analytics Platform}
-  {Genesis of a Data and Analytics Engineering Team, building out a Data Platform. Breaking silos between Data Engineers and Analysts to build T-shaped engineers, increasing a feeling of personal ownership among those engineers. Technical and architectural oversight of new features by facilitating workshops and whiteboard sessions.}
+  {}
+  {}
+  {}
+  {\textit{Data and Analytics Platform}: Merge of the previous Analytics Platform with another (Data Warehousing) team, setting capacity and delivery plans and building programmes and processes to upskill Data Analysts to become Analytics Engineers competent in Scala. Management of the team through a re-architecture of the platform, while increasing the rate at which initiatives were delivered with no increase to budget or headcount}
 
   \entry
-  {March 2022 - January 2023}
-  {Kaluza - a Green Energy PaaS}
-  {Software Engineering Manager - Developer Experience}
-  {Inherited a team of three engineers with low engagement and poor morale. Built a product vision and strategy, including KPIs, walked the team through setting mission/vision (with 100\% buy-in), and set clear progression paths. Through ownership of recruitment, I grew this team to eight people in six months without jeopardising culture, frequently topping the charts for engagement metrics in company-wide surveys.}
+  {}
+  {}
+  {}
+  {\textit{Event Streaming Platform}: Management of a small team of Scala engineers building high performance streaming software. Engagement on this team was low when I joined; most of the team hadn't seen a promotion for several years. By setting up a goal-framing framework and encouraging the team to join squad/ company level initiatives, all IC level engineers on the team had open promotion cases.}
 
   \entry
   {July 2021 - September 2021}


### PR DESCRIPTION
Previous versions of this listed each Kaluza team as if it were a brand new company. The feedback received from one application is that, at first glance, it looked dead jumpy.

This change masks that.

This PR also introduces the `.PHONY` make target `spellcheck` which wraps a call to `aspell` to run against any changed file. It may be invoked as per:

```bash
$ make spellcheck
```